### PR TITLE
Add test suite and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # FlexSim3
+
 a Flex Simulator
+
+## Running Tests
+
+This project uses [PyTest](https://docs.pytest.org/) for its test suite.
+
+To run the tests locally:
+
+```bash
+pip install pytest
+pytest
+```

--- a/flexsim/__init__.py
+++ b/flexsim/__init__.py
@@ -1,0 +1,15 @@
+"""FlexSim core package."""
+
+from .mechanics import (
+    calculate_damage,
+    encounter_occurs,
+    save_game,
+    load_game,
+)
+
+__all__ = [
+    "calculate_damage",
+    "encounter_occurs",
+    "save_game",
+    "load_game",
+]

--- a/flexsim/mechanics.py
+++ b/flexsim/mechanics.py
@@ -1,0 +1,28 @@
+import json
+import random
+from typing import Any, Callable
+
+
+def calculate_damage(attack: int, defense: int) -> int:
+    """Calculate damage dealt.
+
+    Damage is the attack minus defense with a minimum of 1.
+    """
+    return max(attack - defense, 1)
+
+
+def encounter_occurs(rate: float, rng: Callable[[], float] = random.random) -> bool:
+    """Determine if an encounter occurs given a rate and RNG."""
+    return rng() < rate
+
+
+def save_game(state: Any, filename: str) -> None:
+    """Save state to a JSON file."""
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(state, f)
+
+
+def load_game(filename: str) -> Any:
+    """Load game state from a JSON file."""
+    with open(filename, "r", encoding="utf-8") as f:
+        return json.load(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -1,0 +1,24 @@
+from flexsim.mechanics import calculate_damage, encounter_occurs, save_game, load_game
+
+
+def test_calculate_damage():
+    assert calculate_damage(10, 3) == 7
+    assert calculate_damage(3, 5) == 1
+
+
+def test_encounter_occurs_true():
+    rng = iter([0.05]).__next__
+    assert encounter_occurs(0.1, rng) is True
+
+
+def test_encounter_occurs_false():
+    rng = iter([0.2]).__next__
+    assert encounter_occurs(0.1, rng) is False
+
+
+def test_save_and_load(tmp_path):
+    state = {"hp": 10, "items": ["potion"]}
+    filename = tmp_path / "save.json"
+    save_game(state, filename)
+    loaded_state = load_game(filename)
+    assert loaded_state == state


### PR DESCRIPTION
## Summary
- implement core mechanics helpers for damage, encounters, and saving/loading
- add PyTest suite covering damage, encounter rates, and save/load
- run tests in GitHub Actions on pushes and pull requests
- document running tests locally in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac550866508320853fb884aaa256df